### PR TITLE
bugfix/docs build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -34,6 +34,8 @@ jobs:
         sudo cp elk-full.jar /usr/share/plantuml/elk-full.jar
     - name: checkout
       uses: actions/checkout@v4
+    - name: Build and Install nodejs-llhttp
+      uses: ./.github/actions/llhttp-build
     - name: build docs
       run: |
         cmake --preset github-ci-debug

--- a/docs/Doxygen.conf.in
+++ b/docs/Doxygen.conf.in
@@ -969,6 +969,7 @@ INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/pages \
                          @CMAKE_CURRENT_SOURCE_DIR@/../plugincore \
                          @CMAKE_CURRENT_SOURCE_DIR@/../providers \
                          @CMAKE_CURRENT_SOURCE_DIR@/../shell \
+                         @CMAKE_CURRENT_SOURCE_DIR@/../http \
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
- github: Build nodejs-http in the docs deploy build
- docs: Enabale docs for the http module
